### PR TITLE
Update Newt to 1.7.0

### DIFF
--- a/newt/Dockerfile
+++ b/newt/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source=https://github.com/alexmoras/hass-addon-ne
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG NEWT_VERSION="1.6.0"
+ARG NEWT_VERSION="1.7.0"
 ARG BUILD_ARCH
 RUN \
     if [ "$BUILD_ARCH" = "aarch64" ]; then \


### PR DESCRIPTION
Update Newt to version 1.7.0 (changelog: https://github.com/fosrl/newt/releases/tag/1.7.0)
This update is required for compatibility with Pangolin 1.13.0 (https://github.com/fosrl/pangolin/releases/tag/1.13.0)