### PR TITLE
Update NEWT_VERSION to 1.8.0 in Dockerfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: alexmoras
+          username: phil-lipp
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
         uses: home-assistant/builder@master
@@ -24,4 +24,4 @@ jobs:
             --amd64 \
             --aarch64 \
             --target newt \
-            --docker-hub ghcr.io/alexmoras
+            --docker-hub ghcr.io/phil-lipp

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The [Fossorial system - with Pangolin](https://docs.fossorial.io/) at its core -
 
 Newt is the main client, connecting to Pangolin, allowing access to services on the same network as Newt. Install this and connect to your Pangolin instance to allow remote access to Home Assistant, over secure WireGuard tunnels!
 
-[![Add this addon to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexmoras%2Fhass-addon-newt)
+[![Add this addon to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fphil-lipp%2Fhass-addon-newt)
 
-This is a Home Assistant add-on that downloads the Newt binary and runs it on your Home Assistant instance. It exposes the ID, Secret, and Endpoint URL as configuration options within Home Assistant for easy deployment. Visit [the docs](https://github.com/alexmoras/hass-addon-newt/blob/main/newt/DOCS.md) to learn how to install it.
+This is a Home Assistant add-on that downloads the Newt binary and runs it on your Home Assistant instance. It exposes the ID, Secret, and Endpoint URL as configuration options within Home Assistant for easy deployment. Visit [the docs](https://github.com/phil-lipp/hass-addon-newt/blob/main/newt/DOCS.md) to learn how to install it.
 
 _The code for DNS, mTLS, and Log Level is taken from the work done by [adriaanConijn](https://github.com/adriaanConijn/hass-addon-newt)._

--- a/newt/CHANGELOG.md
+++ b/newt/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [07.0 - 2025-12-13
+## [1.9.0-1] - 2026-01-24
+
+### Changed
+- Newt version bumped to 1.9.0. Adds support for olm low power mode in sub packages and iOS/Android clients with rebind support.
+- Adapt versioning to follow Newt's versioning scheme (add-on version now tracks Newt version)
+- Fully fork
+
+## [0.7.0] - 2025-12-13
 
 ### Changed
 - Newt version bumped to 1.7.0 (thanks @phil-lipp), necessary for support on new versions of Pangolin.

--- a/newt/DOCS.md
+++ b/newt/DOCS.md
@@ -11,7 +11,7 @@ Create a new "Site" with `Newt` as the Method. Save the `id`, `secret`, and `end
 
 ## Installation
 1. Add this repository to Home Assistant and install the addon.  
-   [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexmoras%2Fhass-addon-newt)
+   [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fphil-lipp%2Fhass-addon-newt)
 2. Configure the addon in the "Configuration" tab using the configuration documentation below. Hit "Start" and check the "Logs" tab to check the status. On your Pangolin dashboard, you will see the newly created Site status change to "Online".
 3. Visit your Pangolin dashboard and add a new Resource called `Home Assistant`. Choose the correct site that relates to the Home Assistant Newt instance, that you defined in the prerequisites and give your Resource a subdomain.
 4. Make sure the "Enable SSL" option is toggled on, so that you get an automatically generated SSL certificate to encrypt the browser connections.

--- a/newt/Dockerfile
+++ b/newt/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source=https://github.com/alexmoras/hass-addon-ne
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG NEWT_VERSION="1.7.0"
+ARG NEWT_VERSION="1.8.0"
 ARG BUILD_ARCH
 RUN \
     if [ "$BUILD_ARCH" = "aarch64" ]; then \

--- a/newt/Dockerfile
+++ b/newt/Dockerfile
@@ -1,13 +1,13 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-LABEL org.opencontainers.image.source=https://github.com/alexmoras/hass-addon-newt
+LABEL org.opencontainers.image.source=https://github.com/phil-lipp/hass-addon-newt
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG NEWT_VERSION="1.8.0"
+ARG NEWT_VERSION="1.9.0"
 ARG BUILD_ARCH
 RUN \
     if [ "$BUILD_ARCH" = "aarch64" ]; then \

--- a/newt/README.md
+++ b/newt/README.md
@@ -6,8 +6,8 @@ The [Fossorial system - with Pangolin](https://docs.fossorial.io/) at its core -
 
 Newt is the main client, connecting to Pangolin, allowing access to services on the same network as Newt. Install this and connect to your Pangolin instance to allow remote access to Home Assistant, over secure WireGuard tunnels!
 
-[![Add this addon to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexmoras%2Fhass-addon-newt)
+[![Add this addon to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fphil-lipp%2Fhass-addon-newt)
 
-This is a Home Assistant add-on that downloads the Newt binary and runs it on your Home Assistant instance. It exposes the ID, Secret, and Endpoint URL as configuration options within Home Assistant for easy deployment. Visit [the docs](https://github.com/alexmoras/hass-addon-newt/blob/main/newt/DOCS.md) to learn how to install it.
+This is a Home Assistant add-on that downloads the Newt binary and runs it on your Home Assistant instance. It exposes the ID, Secret, and Endpoint URL as configuration options within Home Assistant for easy deployment. Visit [the docs](https://github.com/phil-lipp/hass-addon-newt/blob/main/newt/DOCS.md) to learn how to install it.
 
 _The code for DNS, mTLS, and Log Level is taken from the work done by [adriaanConijn](https://github.com/adriaanConijn/hass-addon-newt)._

--- a/newt/config.yaml
+++ b/newt/config.yaml
@@ -4,7 +4,7 @@ maintainer: phil-lipp
 url: https://docs.fossorial.io
 version: "1.9.0-1"
 slug: "newt"
-image: "ghcr.io/phil-lipp/image-{arch}-hass-addon-newt"
+image: "ghcr.io/phil-lipp/{arch}-newt"
 boot: auto
 init: false
 arch:

--- a/newt/config.yaml
+++ b/newt/config.yaml
@@ -1,10 +1,10 @@
 name: "Newt - Pangolin Tunnels"
 description: "Secure remote access with Pangolin tunnels."
-maintainer: Alex Moras <alex@codesix.net>
+maintainer: phil-lipp
 url: https://docs.fossorial.io
-version: "0.7.0"
+version: "1.9.0-1"
 slug: "newt"
-image: "ghcr.io/alexmoras/image-{arch}-hass-addon-newt"
+image: "ghcr.io/phil-lipp/image-{arch}-hass-addon-newt"
 boot: auto
 init: false
 arch:

--- a/newt/run.sh
+++ b/newt/run.sh
@@ -2,26 +2,26 @@
 # shellcheck shell=bash
 set -e
 
-bashio::log.info "Starting Newt..."
+bashio.log.info "Starting Newt..."
 
 # Build command arguments
 ARGS=(
-    "--id" "$(bashio::config 'id')"
-    "--secret" "$(bashio::config 'secret')"
-    "--endpoint" "$(bashio::config 'endpoint')"
-    "--log-level" "$(bashio::config 'log_level')"
+    "--id" "$(bashio.config 'id')"
+    "--secret" "$(bashio.config 'secret')"
+    "--endpoint" "$(bashio.config 'endpoint')"
+    "--log-level" "$(bashio.config 'log_level')"
 )
 
 # Add DNS if configured
-if bashio::config.has_value 'dns' && [ -n "$(bashio::config 'dns')" ]; then
-    ARGS+=("--dns" "$(bashio::config 'dns')")
+if bashio.config.has_value 'dns' && [ -n "$(bashio.config 'dns')" ]; then
+    ARGS+=("--dns" "$(bashio.config 'dns')")
 fi
 
-if bashio::config.has_value 'tls_client_cert' && [ -n "$(bashio::config 'tls_client_cert')" ]; then
-    ARGS+=("--tls-client-cert" "$(bashio::config 'tls_client_cert')")
+if bashio.config.has_value 'tls_client_cert' && [ -n "$(bashio.config 'tls_client_cert')" ]; then
+    ARGS+=("--tls-client-cert" "$(bashio.config 'tls_client_cert')")
 fi
 
-if bashio::config.has_value 'docker' && [ "$(bashio::config 'docker')" = "true" ]; then
+if bashio.config.has_value 'docker' && [ "$(bashio.config 'docker')" = "true" ]; then
     ARGS+=("--docker-socket" "/var/run/docker.sock")
 fi
 

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: "Newt - Pangolin Tunnels"
-maintainer: Alex Moras <alex@codesix.net>
-url: https://github.com/alexmoras/hass-addon-newt
+maintainer: phil-lipp
+url: https://github.com/phil-lipp/hass-addon-newt


### PR DESCRIPTION
Update Newt to 1.8.0 for matching Pangolin 1.14.0's recommended version. It is not required, but still advised to update.